### PR TITLE
Fix Winner Cars Coming On top Of Navbar

### DIFF
--- a/style.css
+++ b/style.css
@@ -26,6 +26,7 @@ body {
   width: 100%;
   background: transparent;
   position: fixed;
+  z-index: 5;
 }
 
 .nav-items {


### PR DESCRIPTION
In this PR I have fixed the issue of winner car images coming on top of Mobile Menu in the About section
